### PR TITLE
feat: add support for query operators

### DIFF
--- a/src/Collection.js
+++ b/src/Collection.js
@@ -81,7 +81,7 @@ class Collection extends OrbitdbStore {
      * 
      * 
      *  db.collection.update(
-        <query>,
+        <filter>,
         <modification>,
         {
             upsert: <boolean>,

--- a/src/CollectionIndex.js
+++ b/src/CollectionIndex.js
@@ -1,4 +1,5 @@
 const parseAndUpdate = require('./operators/UpdateOperators')
+const parseAndFind = require('./operators/QueryOperators')
 
 class CollectionIndex {
     constructor() {
@@ -9,51 +10,13 @@ class CollectionIndex {
         return this._index[key]
     }
     async find(query) {
-        var results = [];
-        var index = this._index;
-        for (var id in index) {
-            var doc = index[id];
-            var match = true;
-
-            for (var key in query) {
-                if (!doc[key]) {
-                    match = false;
-                    break;
-                }
-                if (doc[key] !== query[key]) {
-                    match = false;
-                    break;
-                }
-            }
-
-            if (match) {
-                results.push(doc);
-            }
-        }
-        return results;
+        let res = parseAndFind(query, this._index, false)
+        return res
     }
 
     async findOne(query) {
-        var index = this._index;
-        for (var id in index) {
-            var doc = index[id];
-            var match = true;
-
-            for (var key in query) {
-                if (!doc[key]) {
-                    match = false;
-                    break;
-                }
-                if (doc[key] !== query[key]) {
-                    match = false;
-                    break;
-                }
-            }
-
-            if (match) {
-                return doc;
-            }
-        }
+        let res = parseAndFind(query, this._index, true)
+        return res
     }
 
     async distinct(key, query) {

--- a/src/operators/QueryOperators.js
+++ b/src/operators/QueryOperators.js
@@ -1,0 +1,356 @@
+module.exports = parseAndFind = (query, docs, findOne = false) => { 
+    var docs = Object.values(docs);
+    if (!findOne) {
+        return docs.filter(doc => { 
+            return evaluateQuery(doc, query)
+        })
+    }
+    else {
+        for (let i = 0; i < docs.length; i++) {
+            if (evaluateQuery(docs[i], query)) {
+                return docs[i];
+            }
+        }
+        return {}
+    }
+}
+
+/* 
+Possible queries 
+
+    with operators
+    
+    {
+        $and: 
+        [ 
+            { qty: { $lt: 20, $gt: 10 } }, 
+            { age: { $lt: 20, $gt: 10 } },
+            { bal: { $lt: 20, $gt: 10 } },
+        ] 
+    }
+
+
+    without operators
+
+    {
+        age: 10, bal: 50
+    }
+
+    {
+        pets: ["cat", "dog"], names: ["fluffy", "tommy"]
+    }
+
+    {
+        name: {"fname": "elon", "lname": "musk"},
+        companies: {"space": "spacex", "car": "tesla"}
+    }
+
+
+    mix
+
+    {
+        $and: 
+        [ 
+            { qty: { $lt: 20, $gt: 10 } }, 
+            { age: 10 },
+            { name: {"fname": "elon", "lname": "musk"}  },
+        ] 
+    }
+*/
+
+/**
+ * Evaluates if a document satisfies a condition or not. 
+ * 
+ * @param {JSON Object} doc 
+ * @param {JSON Object} query 
+ * @returns {boolean}
+ */
+
+const evaluateQuery = (doc, query) => { 
+    let res;
+    for (field in query) { 
+        // check for comparison operators by "$"
+        if (field[0] === "$") {
+            switch (field) {
+                case "$and":
+                    /**
+                     * $and: 
+                        [ 
+                            { qty: { $lt: 20, $gt: 10 } }, 
+                            { age: 10 },
+                            { bal: { $lt: 20, $gt: 10 } },
+                        ]
+                     */
+                    res = true;
+                    query[field].forEach(condition => { 
+                        res = res && evaluateCondition(condition, doc)
+                    })
+                    break;
+                case "$or":
+                    /**
+                     * $or: 
+                        [ 
+                            { qty: { $lt: 20, $gt: 10 } }, 
+                            { age: 10 },
+                            { bal: { $lt: 20, $gt: 10 } },
+                        ]
+                     */
+                    res = false
+                    for (let i = 0; i < query[field].length; i++) {
+                        if (evaluateCondition(query[field][i], doc)) {
+                            res = true;
+                            break;
+                        }
+                    }
+                    break;
+                default:
+                    throw new Error(`${operator} comparison operator is not supported`)
+            }
+        }
+
+        
+
+        // if not, then treat it as a doc field or single line operator query
+        // { fname: "vasa", lname: "develop" }
+        // { qty: { $lt: 20, $gt: 10 }, age: { $lt: 20, $gt: 10 } }
+
+        // TODO: Support updates via JSON typed field. Eg, "user.age"
+        else {
+            res = true
+            Object.keys(query).forEach(field => { 
+                let check = {}
+                check[field] = query[field]
+                res = res && evaluateCondition(check, doc)
+            })
+        }
+    }
+    return res;
+}
+
+/**
+ * Evaluates if a condition is satisfied by a specific field value.
+ * 
+ * @param {JSON Object} condition 
+ * @param {JSON Object} doc 
+ * @returns {boolean} 
+ */
+
+const evaluateCondition = (condition, doc) => {
+    var res = true;
+    Object.keys(condition).forEach(field => { 
+        //Check if condition[field] is a JSON object with keys having "$" character 
+        if (condition[field].constructor === Object && (Object.keys(condition[field]).length > 0)) {
+            var logicConditions = Object.keys(condition[field])
+            if (logicConditions[0][0] === "$") {
+                //{ qty: { $lt: 20, $gt: 10 } }
+                logicConditions.forEach(operator => {
+                    switch (operator) {
+                        case "$lt":
+                            res = res && lt(doc[field], condition[field][operator])
+                            break;
+                        case "$gt":
+                            res = res && gt(doc[field], condition[field][operator])
+                            break;
+                        case "$lte":
+                            res = res && lte(doc[field], condition[field][operator])
+                            break;
+                        case "$gte":
+                            res = res && gte(doc[field], condition[field][operator])
+                            break;
+                        default:
+                            throw new Error(`${operator} logical operator is not supported`)
+                    }
+                })
+            }
+            else {
+                //{qty: {"fname": "vasa", "lname": "develop"}}
+                res = res && jsonEqual(doc[field], condition[field])
+            }
+        }
+        else {
+            //{qty: [1,2]}
+            if (condition[field].constructor === Array) {
+                res = res && arraysEqual(doc[field], condition[field])
+            }
+            //{qty: {}}
+            else if (condition[field].constructor === Object) {
+                res = res && jsonEqual(doc[field], condition[field])
+            }
+            //{ qty: 30 }
+            //{qty: null}
+            else {
+                res = res && (doc[field] === condition[field])
+            }
+        }
+        
+    })
+    return res
+}
+
+
+// Comparison
+
+/**
+ * 
+ * @param {JSON Object} query 
+ * @param {Array} docs 
+ */
+
+const eq = (argValue, comparisonValue) => {
+    return (argValue === comparisonValue)
+}
+
+/**
+ * 
+ * @param {JSON Object} query 
+ * @param {Array} docs 
+ */
+
+const gt = (argValue, comparisonValue) => {
+    return (argValue > comparisonValue)
+}
+
+/**
+ * 
+ * @param {JSON Object} query 
+ * @param {Array} docs 
+ */
+
+const gte = (argValue, comparisonValue) => {
+    return (argValue >= comparisonValue)
+}
+
+/**
+ * 
+ * @param {JSON Object} query 
+ * @param {Array} docs 
+ */
+
+const inop = (argValue, comparisonValue) => {
+    return docs
+}
+
+/**
+ * 
+ * @param {JSON Object} query 
+ * @param {Array} docs 
+ */
+
+const lt = (argValue, comparisonValue) => {
+    return (argValue < comparisonValue)
+}
+
+/**
+ * 
+ * @param {JSON Object} query 
+ * @param {Array} docs 
+ */
+
+const lte = (argValue, comparisonValue) => {
+    return (argValue <= comparisonValue)
+}
+
+/**
+ * 
+ * @param {JSON Object} query 
+ * @param {Array} docs 
+ */
+
+const ne = (arg, val) => {
+    return docs
+}
+
+/**
+ * 
+ * @param {JSON Object} query 
+ * @param {Array} docs 
+ */
+
+const nin = (arg, val) => {
+    return docs
+}
+
+// Logical
+
+
+/**
+ * 
+ * @param {JSON Object} query 
+ * @param {Array} docs 
+ */
+
+//$and
+
+/**
+ * 
+ * @param {JSON Object} query 
+ * @param {Array} docs 
+ */
+
+const not = (arg, val) => {
+    return docs
+}
+
+/**
+ * 
+ * @param {JSON Object} query 
+ * @param {Array} docs 
+ */
+
+const nor = (arg, val) => {
+    return docs
+}
+
+/**
+ * 
+ * @param {JSON Object} query 
+ * @param {Array} docs 
+ */
+
+//$or
+
+// Element
+
+
+/**
+ * 
+ * @param {JSON Object} query 
+ * @param {Array} docs 
+ */
+
+const exists = (arg, val) => {
+    return docs
+}
+
+/**
+ * 
+ * @param {JSON Object} query 
+ * @param {Array} docs 
+ */
+
+const type = (arg, val) => {
+    return docs
+}
+
+
+// Utility Functions
+
+const arraysEqual = (a, b) => {
+  if (a === b) return true;
+  if (a == null || b == null) return false;
+  if (a.length != b.length) return false;
+
+  // If you don't care about the order of the elements inside
+  // the array, you should sort both arrays here.
+  // Please note that calling sort on an array will modify that array.
+  // you might want to clone your array first.
+
+  for (var i = 0; i < a.length; ++i) {
+    if (a[i] !== b[i]) return false;
+  }
+  return true;
+}
+
+function jsonEqual(a,b) {
+    return JSON.stringify(a) === JSON.stringify(b);
+}

--- a/test/benchmarks/benchmark.query.js
+++ b/test/benchmarks/benchmark.query.js
@@ -20,8 +20,8 @@ let numberOfEntries = 5000;
 // Main loop
 const queryLoop = async (db) => {
   
-  await db.findOne({nombre: "kim"})
-  totalQueries ++
+  await db.find({ fname: "vasa", lname: "develop" })
+  totalQueries++
   lastTenSeconds ++
   queriesPerSecond ++
   setImmediate(() => queryLoop(db))
@@ -62,7 +62,10 @@ ipfs.on('ready', async () => {
       for(var x = 0; x < numberOfEntries; x++) {
         await db.insertOne({
           id: Crypto.randomBytes(6).toString("base64"),
-          nombre: "kim"
+          fname: "vasa",
+          lname: "develop",
+          age: 22,
+          bal: 1000
         })
       }
       // Metrics output


### PR DESCRIPTION
### Supported Conditional Operators

- $lt
- $gt
- $lte
- $gte

### Supported Logical Operators

- $and
- $or

### Observations

1. The benchmark seems to have taken a big hit.

```
461 queries per second, 17695 queries in 40 seconds (Oplog: 5000)
488 queries per second, 18183 queries in 41 seconds (Oplog: 5000)
562 queries per second, 18745 queries in 42 seconds (Oplog: 5000)
652 queries per second, 19397 queries in 43 seconds (Oplog: 5000)
578 queries per second, 19975 queries in 44 seconds (Oplog: 5000)
611 queries per second, 20586 queries in 45 seconds (Oplog: 5000)
541 queries per second, 21127 queries in 46 seconds (Oplog: 5000)
457 queries per second, 21584 queries in 47 seconds (Oplog: 5000)
544 queries per second, 22128 queries in 48 seconds (Oplog: 5000)
561 queries per second, 22689 queries in 49 seconds (Oplog: 5000)
--> Average of 535 q/s in the last 10 seconds
```

2. The benchmarks have the same results, irrespective of how complex is the query.

License: MIT
Signed-off-by: Vaibhav Saini <vasa@dappkit.io>